### PR TITLE
allow react >=0.13.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "jquery": ">=2.1.3",
     "moment": ">=2.9.0",
-    "react": ">=0.12.0"
+    "react": "0.12.x || >=0.13.0-beta.1"
   },
   "devDependencies": {
     "bootstrap": "^3.3.2",


### PR DESCRIPTION
if >=0.13.0-beta.1 is installed, react-bootstrap-daterangepicker will use it, otherwise it will use/install 0.12.x