### PR TITLE
getOptionsFromProps should never return undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ module.exports = React.createClass({
 				options[option] = props[option];
 			}
 		});
-		return options;
+		return options || {};
 	},
 	setOptionsFromProps: function () {
 		var currentOptions = this.getOptionsFromProps();


### PR DESCRIPTION
We should be able to rely on this method returning an object, even if it's empty.