### PR TITLE
Prevent clash with Array-polyfills by removing use of "for" loop.

### DIFF
--- a/lib/daterangepicker.js
+++ b/lib/daterangepicker.js
@@ -782,11 +782,11 @@
                         classes.push('in-range');
 
                     var cname = '', disabled = false;
-                    for (var i = 0; i < classes.length; i++) {
-                        cname += classes[i] + ' ';
-                        if (classes[i] == 'disabled')
+                    classes.forEach(function (className) {
+                        cname += className + ' ';
+                        if (className == 'disabled')
                             disabled = true;
-                    }
+                    });
                     if (!disabled)
                         cname += 'available';
 


### PR DESCRIPTION
Thanks for this!

In most situations, Array iteration is done via the ```forEach``` array method, but not here.

Iterating via a ```for```-loop as done here is less verbose, and more error-prone (as in my case, where an Array-polyfill breaks the rendering...)