### PR TITLE
Fix case where root was undefined

### DIFF
--- a/lib/daterangepicker.js
+++ b/lib/daterangepicker.js
@@ -8,7 +8,7 @@
 
 (function(root, factory) {
 
-  if (typeof define === 'function' && define.amd) {
+  if (root && typeof define === 'function' && define.amd) {
     define(['moment', 'jquery', 'exports'], function(momentjs, $, exports) {
       root.daterangepicker = factory(root, exports, momentjs, $);
     });


### PR DESCRIPTION
This was showing up for me with react 0.13.3 and jquery 2.1.4 but i belive the error unrelated to these and rather related to webpack and it's magic to work with both amd and commonJS modules.

Didn't try to trackdown the root cause here, but we've been using this fix for a while without noticing any other problems.

This fixes #34