### PR TITLE
remount daterangepicker on rerender

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,15 @@ module.exports = React.createClass({
 		}
 	},
 	componentDidMount: function () {
+		this.initializeDateRangePicker();
+	},
+	componentWillUnmount: function () {
+		this.removeDateRangePicker();
+	},
+	removeDateRangePicker: function() {
+		this.$picker.data('daterangepicker').remove();
+	},
+	initializeDateRangePicker: function() {
 		var $this = this;
 		$ = (window.jQuery && window.jQuery.fn.daterangepicker)? window.jQuery : $;
 		$this.$picker = $(this.refs.picker);
@@ -58,10 +67,12 @@ module.exports = React.createClass({
 			$this.$picker.on(lcase + '.daterangepicker', $this.makeEventHandler('on' + event));
 		});
 	},
-	componentWillUnmount: function () {
-		this.$picker.data('daterangepicker').remove();
-	},
 	render: function () {
+		if (this.$picker) {
+			this.removeDateRangePicker();
+			this.initializeDateRangePicker();
+		}
+
 		this.setOptionsFromProps();
 		return React.createElement(
 			'div',


### PR DESCRIPTION
Currently if you change the 'singleDatePicker' prop, the daterangepicker
does not rerender to match the new property value.