### PR TITLE
Only update options from props when props change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,8 @@ module.exports = React.createClass({
 			}
 		}.bind(this);
 	},
-	getOptionsFromProps: function () {
-		var options, props = this.props;
+	getOptionsFromProps: function (props) {
+		var options, props = props || this.props;
 		this.options.forEach(function (option) {
 			if (props.hasOwnProperty(option)) {
 				options = options || {};
@@ -35,8 +35,7 @@ module.exports = React.createClass({
 		});
 		return options || {};
 	},
-	setOptionsFromProps: function () {
-		var currentOptions = this.getOptionsFromProps();
+	setOptionsFromProps: function (currentOptions) {
 		var keys = Object.keys(currentOptions);
 		var $this = this;
 		if ($this.$picker) {
@@ -45,6 +44,20 @@ module.exports = React.createClass({
 					$this.$picker.data('daterangepicker')[key] = currentOptions[key];
 				});
 			}
+		}
+	},
+	componentWillReceiveProps: function(nextProps) {
+		var $this = this;
+		if ($this.$picker) {
+			var currentOptions = $this.getOptionsFromProps();
+			var nextOptions = $this.getOptionsFromProps(nextProps);
+			var changedOptions = {};
+			$this.options.forEach(function (option) {
+				if (currentOptions[option] !== nextOptions[option]) {
+					changedOptions[option] = nextOptions[option];
+				}
+			});
+			$this.setOptionsFromProps(changedOptions);
 		}
 	},
 	componentDidMount: function () {
@@ -69,7 +82,6 @@ module.exports = React.createClass({
 		});
 	},
 	render: function () {
-		this.setOptionsFromProps();
 		return React.createElement(
 			'div',
 			objectAssign({ref: 'picker'},  this.props),


### PR DESCRIPTION
I found that using `undefined` for `startDate` and `endDate` would result in the instance variables getting clobbered on re-render. This changes the logic from occurring during `render` to occurring during `componentWillReceiveProps`, and only updating them if they are not `===`.