### PR TITLE
Use setStart/EndDate() when respective props change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,13 @@ module.exports = React.createClass({
 		if ($this.$picker) {
 			if (currentOptions) {
 				keys.forEach(function (key) {
-					$this.$picker.data('daterangepicker')[key] = currentOptions[key];
+					if (key === 'startDate') {
+						$this.$picker.data('daterangepicker').setStartDate(currentOptions[key]);
+					} else if (key === 'endDate') {
+						$this.$picker.data('daterangepicker').setEndDate(currentOptions[key]);
+					} else {
+						$this.$picker.data('daterangepicker')[key] = currentOptions[key];
+					}
 				});
 			}
 		}


### PR DESCRIPTION
One more change: I found the bug would still manifest when the props transitioned from undefined, to dates, back to undefined. This will now route `startDate` / `endDate` prop changes through the `setStartDate` and `setEndDate` setters on the daterangepicker, which will properly convert those to 12:00am and 11:59pm respectively.