### PR TITLE
Don't pass own props to the div

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,11 +90,58 @@ module.exports = React.createClass({
 			$this.$picker.on(lcase + '.daterangepicker', $this.makeEventHandler('on' + event));
 		});
 	},
+	propTypes: {
+		alwaysShowCalendars: React.PropTypes.bool,
+		applyClass: React.PropTypes.string,
+		autoApply: React.PropTypes.bool,
+		autoUpdateInput: React.PropTypes.bool,
+		buttonClasses: React.PropTypes.array,
+		cancelClass: React.PropTypes.string,
+		dateLimit: React.PropTypes.object,
+		drops: React.PropTypes.oneOf(['down', 'up']),
+		endDate: React.PropTypes.oneOfType([
+			React.PropTypes.object,
+			React.PropTypes.string,
+		]),
+		isInvalidDate: React.PropTypes.func,
+		linkedCalendars: React.PropTypes.bool,
+		locale: React.PropTypes.object,
+		maxDate: React.PropTypes.oneOfType([
+			React.PropTypes.object,
+			React.PropTypes.string,
+		]),
+		minDate: React.PropTypes.oneOfType([
+			React.PropTypes.object,
+			React.PropTypes.string,
+		]),
+		onApply: React.PropTypes.func,
+		onCancel: React.PropTypes.func,
+		onEvent: React.PropTypes.func,
+		onHide: React.PropTypes.func,
+		onHideCalendar: React.PropTypes.func,
+		onShow: React.PropTypes.func,
+		onShowCalendar: React.PropTypes.func,
+		opens: React.PropTypes.oneOf(['left', 'right', 'center']),
+		ranges: React.PropTypes.object,
+		showDropdowns: React.PropTypes.bool,
+		showWeekNumbers: React.PropTypes.bool,
+		singleDatePicker: React.PropTypes.bool,
+		startDate: React.PropTypes.oneOfType([
+			React.PropTypes.object,
+			React.PropTypes.string,
+		]),
+		timePicker: React.PropTypes.bool,
+		timePickerIncrement: React.PropTypes.number,
+		timePicker24hour: React.PropTypes.bool,
+		timePickerSeconds: React.PropTypes.bool,
+	},
 	render: function () {
-		return React.createElement(
-			'div',
-			objectAssign({ref: 'picker'},  this.props),
-			this.props.children
-		);
+		var props = objectAssign({ref: 'picker'}, this.props);
+
+		Object.keys(this.constructor.propTypes).forEach(function(key) {
+			delete props[key];
+		});
+
+		return React.createElement('div', props, this.props.children);
 	}
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,7 +132,7 @@ module.exports = React.createClass({
 		]),
 		timePicker: React.PropTypes.bool,
 		timePickerIncrement: React.PropTypes.number,
-		timePicker24hour: React.PropTypes.bool,
+		timePicker24Hour: React.PropTypes.bool,
 		timePickerSeconds: React.PropTypes.bool,
 	},
 	render: function () {


### PR DESCRIPTION
Since react-15, it is not allowed to pass unknown props to DOM components. This patch adds handling of propTypes to the DateRangePicker object and also removes all recognized props before passing all props to the root div element.

Solves #84, #80