### PR TITLE
Time is not being preserved  when  timepicker was enabled

### DIFF
--- a/lib/daterangepicker.js
+++ b/lib/daterangepicker.js
@@ -873,7 +873,7 @@
 
                 //Preserve the time already selected
                 var timeSelector = this.container.find('.calendar.right .calendar-time div');
-                if (!this.endDate && timeSelector.html() != '') {
+                if (timeSelector.html() != '') {
 
                     selected.hour(timeSelector.find('.hourselect option:selected').val() || selected.hour());
                     selected.minute(timeSelector.find('.minuteselect option:selected').val() || selected.minute());


### PR DESCRIPTION
the `!this.endDate` was causing the date picker with `timePicker` and `timePicker24Hour` parameters to reset the hour time dropdown to `0`.
You can reproduce it in the demo page as well.

I believe this bug was introduced in the latest release, please consider high priority for this issue.
Linking bootstrap-daterangepicker https://github.com/dangrossman/bootstrap-daterangepicker/pull/1295

@skratchdot can you help us solving this issue?