### PR TITLE
Allow use function as range value

### DIFF
--- a/lib/daterangepicker.js
+++ b/lib/daterangepicker.js
@@ -305,11 +305,15 @@
 
                 if (typeof options.ranges[range][0] === 'string')
                     start = moment(options.ranges[range][0], this.locale.format);
+                else if (typeof options.ranges[range][0] === 'function')
+                    start = options.ranges[range][0]();
                 else
                     start = moment(options.ranges[range][0]);
 
                 if (typeof options.ranges[range][1] === 'string')
                     end = moment(options.ranges[range][1], this.locale.format);
+                else if (typeof options.ranges[range][1] === 'function')
+                    start = options.ranges[range][1]();
                 else
                     end = moment(options.ranges[range][1]);
 


### PR DESCRIPTION
It is useful then page was opened more than one day ago, for example it's might be admin page. Now range 'Yesterday' has values [moment().utc(), moment().utc()] will return yesterday's date if page was open yesterday, but if values will [()=>moment().utc(), ()=>moment().utc()] it return current date forever.
P.S. sorry for my english