### PR TITLE
fix `isCustomDate` proptype

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -107,7 +107,7 @@ module.exports = createReactClass({
 			PropTypes.object,
 			PropTypes.string,
 		]),
-		isCustomDate: PropTypes.bool,
+		isCustomDate: PropTypes.func,
 		isInvalidDate: PropTypes.func,
 		linkedCalendars: PropTypes.bool,
 		locale: PropTypes.object,


### PR DESCRIPTION
`isCustomDate` is a function per the [doc](http://www.daterangepicker.com/#options)

Fixes the React warning
![image](https://user-images.githubusercontent.com/2559439/29499866-d77e1282-85ce-11e7-81ae-bd50d9bd05e0.png)
