### PR TITLE
Fix for camelCase events not firing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,8 +90,8 @@ module.exports = createReactClass({
 		$this.$picker.daterangepicker(this.getOptionsFromProps());
 		// attach event listeners
 		['Show', 'Hide', 'ShowCalendar', 'HideCalendar', 'Apply', 'Cancel'].forEach(function (event) {
-			var lcase = event.toLowerCase();
-			$this.$picker.on(lcase + '.daterangepicker', $this.makeEventHandler('on' + event));
+			var cCase = event.charAt(0).toLowerCase() + event.slice(1);
+			$this.$picker.on(cCase + '.daterangepicker', $this.makeEventHandler('on' + event));
 		});
 	},
 	propTypes: {


### PR DESCRIPTION
An example of this is `onShowCalendar` gets incorrectly mapped to `showcalendar`, This needs to be `showCalendar` for the listener to be registered correctly.

This fix preserves the camelCase format of the events being listened to, allowing the callbacks to fire.