### PR TITLE
Fix #44: daysOfWeek breaks after second render when firstDay != 0

### DIFF
--- a/lib/daterangepicker.js
+++ b/lib/daterangepicker.js
@@ -272,15 +272,6 @@
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
 
-        // update day names order to firstDay
-        if (this.locale.firstDay != 0) {
-            var iterator = this.locale.firstDay;
-            while (iterator > 0) {
-                this.locale.daysOfWeek.push(this.locale.daysOfWeek.shift());
-                iterator--;
-            }
-        }
-
         var start, end, range;
 
         //if no start/end dates set, check if an input element contains initial values
@@ -760,6 +751,11 @@
             // add week number label
             if (this.showWeekNumbers || this.showISOWeekNumbers)
                 html += '<th class="week">' + this.locale.weekLabel + '</th>';
+
+            // update day names order to firstDay
+            var firstDay = this.locale.firstDay;
+            var days = this.locale.daysOfWeek;
+            var daysOfWeek = Array.prototype.concat(days.slice(firstDay), days.slice(0, firstDay));
 
             $.each(this.locale.daysOfWeek, function(index, dayOfWeek) {
                 html += '<th>' + dayOfWeek + '</th>';


### PR DESCRIPTION
Moves the computation of the `daysOfWeek` from initialization to `renderCalendar`, so behavior stays the same on all renders. Also simplifies code.