### PR TITLE
new other react date picker req

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Release notes can be found in the
 - [react-date-range](https://github.com/Adphorus/react-date-range)
 - [react-dates](https://github.com/airbnb/react-dates)
 - [react-datepicker](https://github.com/Hacker0x01/react-datepicker)
+- [react-datetimerange-picker](https://github.com/wojtekmaj/react-datetimerange-picker)
 
 **NOTE: Please submit a PR if there are other date pickers you can recommend**
 


### PR DESCRIPTION
Good docs, easy to use. 

Found because I couldn't get your date picker to open its calendar in my application. Tried all examples. DK why and no errors. 